### PR TITLE
Fix template template

### DIFF
--- a/src/clj/new/template.clj
+++ b/src/clj/new/template.clj
@@ -8,7 +8,7 @@
   (let [render (renderer "template")
         data {:raw-name name
               :name (project-name name)
-              :sanitized (sanitize name)
+              :sanitized (sanitize (project-name name))
               :placeholder "{{sanitized}}"
               :year (year)
               :date (date)}]

--- a/src/clj/new/template/temp.clj
+++ b/src/clj/new/template/temp.clj
@@ -1,12 +1,12 @@
 (ns clj.new.{{name}}
-  (:require [clj.new.templates :refer [renderer name-to-path ->files]]))
+  (:require [clj.new.templates :refer [renderer project-name name-to-path ->files]]))
 
 (def render (renderer "{{name}}"))
 
 (defn {{name}}
   "FIXME: write documentation"
   [name]
-  (let [data {:name name
+  (let [data {:name (project-name name)
               :sanitized (name-to-path name)}]
     (println "Generating fresh 'clj new' {{name}} project.")
     (->files data


### PR DESCRIPTION
Currently with the code in master, the template generator produces a project with invalid src tree paths. 

Also, after fixing that issue, the generated template cannot generate a project because `->files` pulls the `:name` key from the data you pass it and tries to use it for the project name. This fails with this message if the name contains periods:
```
Could not create directory /home/me/tmp/com.myname/my-app. Maybe it already exists?  Use -f / --force to overwrite it.
```

Current behavior with code in master:
```
bash-3.2$ clojure -A:new template com.myname/my-template
Checking out: https://github.com/seancorfield/clj-new at 7d0c40a7b80cab045a07216bdb95fc4aa0342549
Generating a project called my-template that is a 'clj-new' template
bash-3.2$ tree my-template/
my-template/
├── CHANGELOG.md
├── LICENSE
├── README.md
├── deps.edn
├── resources
│   └── clj
│       └── new
│           └── com.myname
│               └── my_template
│                   ├── deps.edn
│                   └── foo.clj
└── src
    └── clj
        └── new
            └── com.myname
                └── my_template.clj

9 directories, 7 files
```

With these changes I believe the correct paths are generated:
```
bash-3.2$ clojure -A:local-new template com.myname/my-template
Generating a project called my-template that is a 'clj-new' template
bash-3.2$ tree my-template/
my-template/
├── CHANGELOG.md
├── LICENSE
├── README.md
├── deps.edn
├── resources
│   └── clj
│       └── new
│           └── my_template
│               ├── deps.edn
│               └── foo.clj
└── src
    └── clj
        └── new
            └── my_template.clj

7 directories, 7 files
```

And the generated template successfully creates a project:
```
bash-3.2$ clojure -A:new:local-template my-template com.myname/my-app
Generating fresh 'clj new' my-template project.
bash-3.2$ tree my-app/
my-app/
├── deps.edn
└── src
    └── com
        └── myname
            └── my_app
                └── foo.clj

4 directories, 2 files
```