### PR TITLE
docs: clarify usage of clj-new.generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ There are currently a few built-in generators:
 
 The `file` generator creates files relative to the prefix. It optionally accepts a body, and file extension. Those default to `nil` and `"clj"` respectively.
 ```bash
+# Inside project folder, relying on the clj-new dependency.
 clj -m clj-new.generate file=foo.bar "(ns foo.bar)" "clj"
 ```
 


### PR DESCRIPTION
Specifies that they need `seancorfield/clj-new {:mvn/version "0.8.6"}` in their `:deps` within the `deps.edn` file. 

Unless someone aliases it like: 

```clj
    {:aliases
     {:gen {:extra-deps {seancorfield/clj-new
                         {:mvn/version "0.8.6"}}
            :main-opts ["-m" "clj-new.generate"]}}
     ...}
```