### PR TITLE
Add Calva (including clojure-lsp) to ignore files

### DIFF
--- a/src/clj/new/app/gitignore
+++ b/src/clj/new/app/gitignore
@@ -3,9 +3,10 @@
 /checkouts
 *.jar
 *.class
+/.calva/output-window/
 /.cpcache
 /.lein-*
-/.lsp
+/.lsp/sqlite*.db
 /.nrepl-history
 /.nrepl-port
 /.rebel_readline_history

--- a/src/clj/new/app/hgignore
+++ b/src/clj/new/app/hgignore
@@ -6,8 +6,9 @@ syntax: glob
 .git/**
 
 syntax: regexp
+^.calva/output-window/
 ^.lein-.*
-^.lsp
+^.lsp/sqlite.*\.db
 ^.nrepl-history
 ^.nrepl-port
 ^.rebel_readline_history

--- a/src/clj/new/lib/gitignore
+++ b/src/clj/new/lib/gitignore
@@ -3,9 +3,10 @@
 /checkouts
 *.jar
 *.class
+/.calva/output-window/
 /.cpcache
 /.lein-*
-/.lsp
+/.lsp/sqlite*.db
 /.nrepl-history
 /.nrepl-port
 /.rebel_readline_history

--- a/src/clj/new/lib/hgignore
+++ b/src/clj/new/lib/hgignore
@@ -6,8 +6,9 @@ syntax: glob
 .git/**
 
 syntax: regexp
+^.calva/output-window/
 ^.lein-.*
-^.lsp
+^.lsp/sqlite.*\.db
 ^.nrepl-history
 ^.nrepl-port
 ^.rebel_readline_history

--- a/src/clj/new/polylith/gitignore
+++ b/src/clj/new/polylith/gitignore
@@ -3,9 +3,10 @@
 /checkouts
 *.jar
 *.class
-.cpcache
+/.calva/output-window/
+/.cpcache
 /.lein-*
-/.lsp
+/.lsp/sqlite*.db
 /.nrepl-history
 /.nrepl-port
 /.rebel_readline_history

--- a/src/clj/new/polylith/hgignore
+++ b/src/clj/new/polylith/hgignore
@@ -6,8 +6,9 @@ syntax: glob
 .git/**
 
 syntax: regexp
+^.calva/output-window/
 ^.lein-.*
-^.lsp
+^.lsp/sqlite.*\.db
 ^.nrepl-history
 ^.nrepl-port
 ^.rebel_readline_history

--- a/src/clj/new/template/gitignore
+++ b/src/clj/new/template/gitignore
@@ -3,9 +3,10 @@
 /checkouts
 *.jar
 *.class
+/.calva/output-window/
 /.cpcache
 /.lein-*
-/.lsp
+/.lsp/sqlite*.db
 /.nrepl-history
 /.nrepl-port
 /.rebel_readline_history

--- a/src/clj/new/template/hgignore
+++ b/src/clj/new/template/hgignore
@@ -6,8 +6,9 @@ syntax: glob
 .git/**
 
 syntax: regexp
+^.calva/output-window/
 ^.lein-.*
-^.lsp
+^.lsp/sqlite.*\.db
 ^.nrepl-history
 ^.nrepl-port
 ^.rebel_readline_history


### PR DESCRIPTION
1. Added Calvas output window file to `.gitignore` and `.hgignore`
2. Changed the clojure-lsp ignore entries to target only sqlite db files. (Since clojure-lsp uses the `.lsp` directory also for config.)

I haven't tested the the Mercurial ignores, but added them with regexp syntax so should be fine. (Not sure which globbing variant is used.)