### PR TITLE
Update re-frame example command line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .classpath
 .clj-kondo/.cache
 .cpcache

--- a/README.md
+++ b/README.md
@@ -436,10 +436,10 @@ Here are some examples, generating projects from existing templates:
 This creates a folder called `mywebapp` with a Luminus web application that will use `http-kit`, the H2 database, the Reagent ClojureScript library, and the Buddy library for authentication. The `-main` function is in `yourname.example.webapp.core`, which is in the  `mywebapp/src/clj/yourname/example/webapp/core.clj` file. Note that the [Luminus template](https://github.com/luminus-framework/luminus-template) produces a Leiningen-based project, not a CLI/`deps.edn` one, but you can also tell it to produce a Boot-based project (with `+boot`).
 
 ```
-    clojure -X:new :template re-frame :name yourname/spa :output front-end :args '[+garden +10x +routes]'
+    clojure -X:new :template re-frame :name yourname/spa :output front-end :args '[+garden "+10x" +routes]'
 ```
 
-This creates a folder called `front-end` with a ClojureScript Single Page Application that uses Garden for CSS, `re-frame-10x` for debugging, and Secretary for routing. The entry point is in the `yourname.spa.core` namespace which is in the `front-end/src/cljs/yourname/spa/core.cljs` file. As with Luminus, the [`re-frame` template](https://github.com/day8/re-frame-template) produces a Leiningen-based project, not a CLI/`deps.edn` one.
+This creates a folder called `front-end` with a ClojureScript Single Page Application that uses [re-frame](https://github.com/day8/re-frame) for state management, [Garden](https://github.com/noprompt/garden) for CSS, [re-frame-10x](https://github.com/day8/re-frame-10x) for debugging, and [bidi](https://github.com/juxt/bidi) + [pushy](https://github.com/kibu-australia/pushy) for routing. The entry point is in the `yourname.spa.core` namespace which is in the `front-end/src/cljs/yourname/spa/core.cljs` file. The [`re-frame` template](https://github.com/day8/re-frame-template) produces a [shadow-cljs](https://shadow-cljs.github.io/docs/UsersGuide.html) project, not a CLI/`deps.edn` one. Note that `+10x` needs to be quoted, because it is not a valid EDN symbol.
 
 ```
     clojure -X:new :template electron-app :name yourname/example


### PR DESCRIPTION
Since I got tripped up by not quoting `+10x` in the `:args` vector, I updated the readme to mention that this is needed.

I also added some links and updated about that it is now **bidi** that's used for routing.

Also my Mac insists on ceating `.DS_store` files a bit arbitrarily, so added that to `.gitignore`. 😄 